### PR TITLE
Replace all instances of "/components/" with "/integrations/"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "flume",
   "name": "Flume",
-  "documentation": "https://www.home-assistant.io/components/flume",
+  "documentation": "https://www.home-assistant.io/integrations/flume",
   "requirements": [
     "ratelimit>=2.2.1"
   ],

--- a/sensor.py
+++ b/sensor.py
@@ -2,7 +2,7 @@
 Support for the Flume smart water meter.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.flume/
+https://home-assistant.io/integrations/sensor.flume/
 """
 import logging
 


### PR DESCRIPTION
Replace all instances of `/components/` with `/integrations/` because of the new endpoint on [home-assistant.io](https://home-assistant.io). There's a possibility that HA might delete the `/components` endpoint, so move everything to the `/integrations` endpoint.

The files edited are: `manifest.json` and `sensor.py`